### PR TITLE
patch-v0.2.3

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,3 +1,19 @@
+## Release 0.2.3
+
+### Bug Fixes and Other Changes
+
+* Fixed `nevopy.callbacks.BestGenomeCheckpoint` not working properly with
+  negative fitness values.
+  
+### Breaking Changes
+
+* Removed the `file_prefix` parameter from the
+  `nevopy.callbacks.BestGenomeCheckpoint.__init__` method.
+* Changed the default values of the parameters `out_path` and
+  `min_improvement_pc` of the `nevopy.callbacks.BestGenomeCheckpoint.__init__`
+  method.
+
+
 ## Release 0.2.2
 
 ### Bug Fixes and Other Changes

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -4,6 +4,8 @@
 
 * Fixed `nevopy.callbacks.BestGenomeCheckpoint` not working properly with
   negative fitness values.
+* Fixed `nevopy.neat.visualization.columns_graph_layout` wrongfully positioning
+  hidden nodes when the network had only one column of hidden nodes.
   
 ### Breaking Changes
 

--- a/examples/bipedal_walker/bipedal_walker_easy_neat.py
+++ b/examples/bipedal_walker/bipedal_walker_easy_neat.py
@@ -70,6 +70,7 @@ if __name__ == "__main__":
         make_env=make_env,
         default_num_episodes=10,
         callbacks=[PreProcessObsGymCallback()],
+        env_renderer=ne.utils.GymRenderer(fps=80),
     )
 
     # Creating a new population of NEAT genomes:

--- a/nevopy/neat/visualization.py
+++ b/nevopy/neat/visualization.py
@@ -122,7 +122,7 @@ def columns_graph_layout(genome: "ne.neat.genomes.NeatGenome",
             num_cols = np.ceil(len(genome.hidden_nodes) / h_nodes_per_col)
 
         if num_cols == 1:
-            insert_nodes_col(x=width / 2, nodes=genome.hidden_nodes)
+            insert_nodes_col(x=origin_x + width / 2, nodes=genome.hidden_nodes)
         else:
             next_x = origin_x + 2 * node_size
             space_x = (width - 4 * node_size) / num_cols

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ Guedes Nogueira (Talendar).
 from typing import List
 import setuptools
 
-_VERSION = "0.2.2"
+_VERSION = "0.2.3"
 
 # Short description.
 short_description = "An open source neuroevolution framework for Python."

--- a/tests/test_neat_activation_visualization.py
+++ b/tests/test_neat_activation_visualization.py
@@ -88,7 +88,7 @@ if __name__ == "__main__":
     test_genome = ne.neat.NeatGenome(num_inputs=_NUM_INPUTS,
                                      num_outputs=_NUM_OUTPUTS,
                                      config=ne.neat.NeatConfig())
-    for _ in range(10):
+    for _ in range(3):
         test_genome.add_random_hidden_node(id_handler)
         # genome.add_random_connection(id_handler)
 


### PR DESCRIPTION
* Fixed `nevopy.callbacks.BestGenomeCheckpoint` not working properly with
  negative fitness values.
* Fixed `nevopy.neat.visualization.columns_graph_layout` wrongfully positioning
  hidden nodes when the network had only one column of hidden nodes.
* Removed the `file_prefix` parameter from the
  `nevopy.callbacks.BestGenomeCheckpoint.__init__` method.
* Changed the default values of the parameters `out_path` and
  `min_improvement_pc` of the `nevopy.callbacks.BestGenomeCheckpoint.__init__`
  method.